### PR TITLE
Ensure rspec-core is loaded

### DIFF
--- a/lib/rspec/autotest.rb
+++ b/lib/rspec/autotest.rb
@@ -1,15 +1,10 @@
-require 'rspec/autotest/version'
+require 'rspec/core'
 require 'autotest'
-
-module RSpec
-  module Autotest
-  end
-end
 
 # Derived from the `Autotest` class, extends the `autotest` command to work
 # with RSpec.
 #
-class Autotest::Rspec2 < ::Autotest
+class Autotest::Rspec2 < Autotest
 
   def initialize
     super()


### PR DESCRIPTION
`rspec-core` needs to be loaded to ensure that we can access the path to the RSpec command
