### PR TITLE
ZenTest should be a runtime dependency.

### DIFF
--- a/rspec-autotest.gemspec
+++ b/rspec-autotest.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.8.7'
 
   spec.add_dependency "rspec-core", ">= 2.99.0.beta1", "< 4.0.0"
+  spec.add_dependency "ZenTest",    "~> 4.6"
 
   spec.add_development_dependency "bundler",        "~> 1.3"
   spec.add_development_dependency "rake",           "~> 10.0.0"
   spec.add_development_dependency "aruba",          "~> 0.5"
-  spec.add_development_dependency "ZenTest",        "~> 4.6"
   spec.add_development_dependency "i18n",           "~> 0.6.4"
   spec.add_development_dependency "activesupport",  "~> 3.0"
 end


### PR DESCRIPTION
Seems like this should be a runtime dependency not a dev dependency.

/cc @JonRowe 
