### PR TITLE
Add note about rspec-2/3 conflict to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ generate rspec:install` command.
 
 ## Gotchas
 
+### Autotest style autotest/rspec_rspec2 doesn't seem to exist. Aborting.
+
+This happens if you're using rspec-3.x + rspec-autotest-1.x and you
+still have rspec-core-2.x installed. Unfortunately, the only way to
+get this to work is to uninstall rspec-core-2.x (or remove it from the
+current gemset if you use a tool that supports gemsets).
+
 ### Invalid Option: --tty
 
 The `--tty` option was [added in rspec-core-2.2.1](changelog), and is used


### PR DESCRIPTION
Documents an issue resulting in "Autotest style autotest/rspec_rspec2 doesn't seem to exist. Aborting."

I _think_ an alternative to "the only way" would be to change rspec-core-2.99's autotest/rspec2.rb (so named during the rspec-1 to rspec-2 transition) to autotest/rspec.rb. If it works, than the README advice can include something like "if you need to keep rspec-core-2 installed, upgrade to rspec-2.99" or some such.
