### PR TITLE
Complies with the new way to cherry pick from Rails core_ext.

### DIFF
--- a/lib/rspec/rails/autotest.rb
+++ b/lib/rspec/rails/autotest.rb
@@ -22,6 +22,7 @@
 
 $:.push(*Dir['vendor/rails/*/lib'])
 
+require 'active_support'
 require 'active_support/all'
 require 'autotest/rspec'
 


### PR DESCRIPTION
Additional information in section 1.1.3 at:

http://edgeguides.rubyonrails.org/active_support_core_extensions.html

Before commit, was failing with this stack trace:

$ autotest
(Not running features.  To run features in autotest, set AUTOFEATURE=true.)
loading autotest/rails_rspec

/.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext/module/deprecation.rb:21:in `deprecate': uninitialized constant ActiveSupport::Deprecation (NameError)

	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext/class/delegating_attributes.rb:26:in `<class:Class>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext/class/delegating_attributes.rb:6:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext/class.rb:2:in `require'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext/class.rb:2:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:2:in `require'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:1:in `each'
	from /.rvm/gems/ruby-2.1.5@custos/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:1:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/rspec-autotest-1.0.0/lib/rspec/rails/autotest.rb:25:in `require'
	from /.rvm/gems/ruby-2.1.5@custos/gems/rspec-autotest-1.0.0/lib/rspec/rails/autotest.rb:25:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/rspec-autotest-1.0.0/lib/autotest/rails_rspec.rb:1:in `require'
	from /.rvm/gems/ruby-2.1.5@custos/gems/rspec-autotest-1.0.0/lib/autotest/rails_rspec.rb:1:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/gems/ZenTest-4.11.0/lib/autotest.rb:164:in `require'
	from /.rvm/gems/ruby-2.1.5@custos/gems/ZenTest-4.11.0/lib/autotest.rb:164:in `runner'
	from /.rvm/gems/ruby-2.1.5@custos/gems/ZenTest-4.11.0/bin/autotest:6:in `<top (required)>'
	from /.rvm/gems/ruby-2.1.5@custos/bin/autotest:23:in `load'
	from /.rvm/gems/ruby-2.1.5@custos/bin/autotest:23:in `<main>'
	from /.rvm/gems/ruby-2.1.5@custos/bin/ruby_executable_hooks:15:in `eval'
	from /.rvm/gems/ruby-2.1.5@custos/bin/ruby_executable_hooks:15:in `<main>'
