### PR TITLE
Removed deprecated option from .gemspec

### DIFF
--- a/rspec-autotest.gemspec
+++ b/rspec-autotest.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |spec|
   spec.description   = 'RSpec Autotest integration'
   spec.license       = 'MIT'
 
-  spec.rubyforge_project  = 'rspec'
-
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.rdoc_options  = ['--charset=UTF-8']


### PR DESCRIPTION
This PR is related to https://github.com/rspec/rspec-core/pull/1974
Thank you. 