### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-autotest.gemspec
+++ b/rspec-autotest.gemspec
@@ -12,6 +12,14 @@ Gem::Specification.new do |spec|
   spec.description   = 'RSpec Autotest integration'
   spec.license       = 'MIT'
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-autotest/issues',
+    'changelog_uri'     => "https://github.com/rspec/rspec-autotest/blob/v#{spec.version}/Changelog.md",
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-autotest',
+  }
+
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.rdoc_options  = ['--charset=UTF-8']


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec-autotest after the next release.