### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,42 @@
+# In order to install old Rubies, we need to use old Ubuntu distibution.
+dist: trusty
+email: false
 language: ruby
-script: "script/test_all 2>&1"
-bundler_args: "--standalone --binstubs"
+
+bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 before_install:
-  # We need to ensure the latest version of Rubygems, unless we're on an old Ruby.
-  - gem update --system $(ruby -e "puts '2.7.8' if ENV['RUBY_VERSION'] >= '2.3.0'")
-  - gem update bundler
+  - "script/update_rubygems_and_install_bundler"
+
+cache:
+  directories:
+    - ../bundle
+
+script: "script/test_all 2>&1"
+
 rvm:
   - 1.8.7
-  - ree
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - jruby-18mode
-  - jruby-19mode
-  - rbx-2
-  - rbx-head
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+  - jruby-9.1.7.0 # pin JRuby to this until travis/rvm can install later versions
   - jruby-head
+  - jruby-1.7
+  - rbx-3
+  - ree
   - ruby-head
 env:
   - RSPEC_BRANCH=master
   - RSPEC_BRANCH=2-99-maintenance
 matrix:
   allow_failures:
-    - rvm: rbx-2
     - rvm: jruby-head
-    - rvm: rbx-head
+    - rvm: rbx-3
     - rvm: ruby-head
   fast_finish: true
-

--- a/rspec-autotest.gemspec
+++ b/rspec-autotest.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'activesupport',  '~> 3.0'
   else
     spec.add_development_dependency 'rake',           '>= 10.0.0'
-    spec.add_development_dependency 'activesupport',  '~> 4.1', '>= 4.1.11'
+    spec.add_development_dependency 'activesupport',  '>= 4.1.11'
   end
-  spec.add_development_dependency 'ZenTest',        '>= 4.6'
+  spec.add_development_dependency 'ZenTest',        '>= 4.6', '< 4.12'
 end

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,0 +1,7 @@
+function is_ruby_23_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 2.3)"; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+source script/functions.sh
+
+if is_ruby_23_plus; then
+  yes | gem update --system
+  yes | gem install bundler
+else
+  echo "Warning installing older versions of Rubygems / Bundler"
+  gem update --system '2.7.8'
+  gem install bundler -v '1.17.3'
+fi


### PR DESCRIPTION
Build was red when updating the badges in #32 so this PR restores it to green.
* Updates the travis file from rspec-core
* Updates bundler using the current style from rspec-core
* Updates Ruby versions to latest
* Removes restriction on active support, if it works it works
* Adds restriction on zentest for dev, as they removed autotest to a minitest gem